### PR TITLE
Detailed error reporting

### DIFF
--- a/src/Exceptions/DhlParcelException.php
+++ b/src/Exceptions/DhlParcelException.php
@@ -54,8 +54,13 @@ class DhlParcelException extends Exception
     {
         $object = static::parseResponseBody($response);
 
+        $errorDetails = '';
+        foreach ($object->details as $key => $value) {
+            $errorDetails .= $key . ': ' . $value[0] . "\n";
+        }
+
         return new static(
-            'Error executing API call: '.$object->message,
+            'Error executing API call: '.$object->message. "\n" . $errorDetails,
             $response->getStatusCode(),
             $response,
             $previous


### PR DESCRIPTION
Also shows the details of the response, so the user is more aware of what to do

i.e. when entering an invalid country, the error will be:
```
Error executing API call: The supplied body could not be parsed correctly, see the details field for additional information.
receiver.address.countryCode: Unknown country code 'TEST'
```
instead of:
```
Error executing API call: The supplied body could not be parsed correctly, see the details field for additional information.
```